### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.kubrick.json
+++ b/org.kde.kubrick.json
@@ -11,6 +11,14 @@
         "--socket=fallback-x11",
         "--socket=wayland"
     ],
+    "cleanup": [
+        "/include",
+        "/lib/cmake",
+        "/lib/qml",
+        "/share/carddecks",
+        "/share/doc",
+        "/share/qlogging-categories6"
+    ],
     "modules": [
         "shared-modules/glu/glu-9.json",
         {


### PR DESCRIPTION
KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.

This PR also removes the /share/carddecks folder, which is not required for this game.